### PR TITLE
chore: codify release process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @EasyPost/devex @lanej

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,14 @@ jobs:
       matrix:
         rubyversion: ['2.7', '3.0', '3.1']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: set up ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.rubyversion }}
+          rubygems: "3.0.0"
           bundler-cache: true
+      - name: Install Dependencies
+        run: make install
       - name: run tests
-        run: bundle exec rspec
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+## help - Display help about make targets for this Makefile
+help:
+	@cat Makefile | grep '^## ' --color=never | cut -c4- | sed -e "`printf 's/ - /\t- /;'`" | column -s "`printf '\t'`" -t
+
+## build - Builds the project
+build:
+	gem build toggles.gemspec --strict
+	mkdir -p dist
+	mv *.gem dist/
+
+## clean - Cleans the project
+clean:
+	rm -rf *.gem dist
+
+## install - Install globally from source
+install:
+	bundle install
+
+## publish - Publishes the built gem to Rubygems
+publish:
+	gem push dist/*.gem
+
+## release - Cuts a release for the project on GitHub (requires GitHub CLI)
+# tag = The associated tag title of the release
+release:
+	gh release create ${tag} dist/*
+
+## test - Test the project (and ignore warnings for test output)
+test:
+	bundle exec rspec
+
+.PHONY: help build clean install publish release test

--- a/toggles.gemspec
+++ b/toggles.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
     check whether a given feature should be applied.
   EOF
 
-  s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rspec-its'
-  s.add_development_dependency 'rspec-temp_dir'
+  s.add_development_dependency 'bundler', '~> 2.0'
+  s.add_development_dependency 'rake', '~> 13.0'
+  s.add_development_dependency 'rspec', '~> 3.10'
+  s.add_development_dependency 'rspec-its', '~> 1.3'
+  s.add_development_dependency 'rspec-temp_dir', '~> 1.1'
 end


### PR DESCRIPTION
- Codifies the releasing process like we do with our libs via a Makefile
- Pins development dependencies so `strict` build flag works
- Adds CODEOWNERS file with DevEx and @lanej as reviewers
