### PR TITLE
feat: allow partial subjects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem "pry"
+  gem "pry-byebug"
 end

--- a/lib/toggles/feature/subject.rb
+++ b/lib/toggles/feature/subject.rb
@@ -6,8 +6,13 @@ module Feature
       end
     end
 
-    def self.difference(subjects, others)
-      Set.new((subjects - others) + (others - subjects)).to_a
+    class NotApplicable < StandardError
+      def initialize(args)
+        super("Subjects not applicable for permissions: #{args}")
+      end
+    end
+
+    class Empty < StandardError
     end
   end
 end

--- a/lib/toggles/version.rb
+++ b/lib/toggles/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Toggles
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
 end

--- a/spec/toggles/feature/acceptance/multiple_subjects_spec.rb
+++ b/spec/toggles/feature/acceptance/multiple_subjects_spec.rb
@@ -7,11 +7,11 @@ describe "Feature::MultipleSubjects" do
       user: double(id: 1, logged_in?: false), widget: double(id: 2))).to eq false
     expect(Feature::MultipleSubjects.enabled_for?(
       user: double(id: 1, logged_in?: true), widget: double(id: 3))).to eq false
-  end
 
-  specify "invalid permissions" do
-    expect { Feature::MultipleSubjects.enabled_for?(widget: double) }.
-      to raise_error Feature::Subject::Invalid,
-        "Invalid or missing subjects for permissions: [:user]"
+    expect(Feature::MultipleSubjects.enabled_for?(
+      user: double(id: 1, logged_in?: true))).to eq true
+    expect(Feature::MultipleSubjects.enabled_for?(
+      widget: double(id: 3)
+    )).to eq false
   end
 end

--- a/spec/toggles/feature/permissions_spec.rb
+++ b/spec/toggles/feature/permissions_spec.rb
@@ -22,10 +22,29 @@ describe Feature::Permissions do
                                 user: double(id: 2, logged_in?: true))).to eq false
     end
 
-    specify "invalid subjects" do
-      expect { subject.valid_for?(user: double) }.
-        to raise_error Feature::Subject::Invalid,
-          "Invalid or missing subjects for permissions: [:widget]"
+    specify 'partial subjects are acceptable', :aggregate_failures do
+      # partial subjects that match
+      expect(subject.valid_for?(user: double(id: 1, logged_in?: true))).to eq true
+      expect(subject.valid_for?(widget: double(id: 2))).to eq true
+
+      # partial subjects that do not match
+      expect(subject.valid_for?(widget: double(id: 3))).to eq false
+      expect(subject.valid_for?(user: double(id: 2, logged_in?: true))).to eq false
+    end
+
+    specify "unspecified subjects are not acceptable" do
+      expect { subject.valid_for?(foo: double) }.
+        to raise_error Feature::Subject::NotApplicable,
+          "Subjects not applicable for permissions: [:foo]"
+
+      # partial specification with an invalid subject is still an error
+      expect { subject.valid_for?(user: double(id: 1), foo: double) }.
+        to raise_error Feature::Subject::NotApplicable,
+          "Subjects not applicable for permissions: [:foo]"
+    end
+
+    specify "empty subjects are invalid" do
+      expect { subject.valid_for?({}) }.to raise_error Feature::Subject::Empty
     end
   end
 end

--- a/spec/toggles/feature/subject_spec.rb
+++ b/spec/toggles/feature/subject_spec.rb
@@ -4,12 +4,4 @@ describe Feature::Subject do
 
     its(:message) { is_expected.to eq "Invalid or missing subjects for permissions: [:user]" }
   end
-
-  describe "#difference" do
-    specify do
-      expect(Feature::Subject.difference([:foo, :bar], [:bar])).to eq [:foo]
-      expect(Feature::Subject.difference([:bar], [:foo, :bar])).to eq [:foo]
-      expect(Feature::Subject.difference([:bar], [:foo])).to eq [:bar, :foo]
-    end
-  end
 end


### PR DESCRIPTION
Throw `Feature::Subject::NotApplicable` when an invalid subject is specified.  This allows for better differentiation of error cases.

Given a feature specified as:

```yaml
user:
  id: 1
```

and a feature check like `Feature.enabled?(:check, user_id: 1)` then when the feature was modified to include *additional* constraints like

```yaml
user:
  id: 1
age:
  gt: 3
```

every caller would immediately fail with `Feature::Subject::Invalid`. In production this creates an intensely tight coupling between the caller and feature data source that is effectively impossible to safely modify.

By allowing *partial subject checks* the coupling is removed, allowing for data source additions without active caller errors.

If a subject is specified by the caller but removed from the data source, an error is still created.